### PR TITLE
fix:修复若干问题

### DIFF
--- a/src/main/kotlin/cn/rtast/qwsdk/sub/Astronomy.kt
+++ b/src/main/kotlin/cn/rtast/qwsdk/sub/Astronomy.kt
@@ -92,7 +92,7 @@ class Astronomy {
         alt: Int
     ): SolarElevationAngleBean {
         DateUtil(date).verifyYMD()
-        DateUtil(date).verifyHM()
+        DateUtil(time).verifyHM()
         val url = makeParam(
             "astronomy/solar-elevation-angle",
             mapOf(

--- a/src/main/kotlin/cn/rtast/qwsdk/utils/makeParam.kt
+++ b/src/main/kotlin/cn/rtast/qwsdk/utils/makeParam.kt
@@ -19,7 +19,7 @@ package cn.rtast.qwsdk.utils
 import cn.rtast.qwsdk.QWeather
 
 fun makeParam(prefix: String, params: Map<String, Any?>, type: QWeather.ApiType = QWeather.ApiType.Common): String {
-    lateinit var result: String
+    var result = ""
     for ((k, v) in params.entries) {
         var value = v
         value = when (value) {

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/Initial.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/Initial.kt
@@ -1,7 +1,7 @@
 package cn.rtast.qwsdk.tests
 
 import cn.rtast.qwsdk.QWeather
-import cn.rtast.qwsdk.enums.Plans
+import cn.rtast.qwsdk.QWeather.Plans
 import cn.rtast.qwsdk.tests.errs.NoKeyFoundException
 
 object Initial {

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestAir.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestAir.kt
@@ -16,7 +16,7 @@
 
 package cn.rtast.qwsdk.tests.main
 
-import cn.rtast.qwsdk.enums.Lang
+import cn.rtast.qwsdk.QWeather.Lang
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.randomID
 import org.junit.jupiter.api.Assertions.assertNotNull

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestAstronomy.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestAstronomy.kt
@@ -18,7 +18,6 @@ package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.getCurrentDate
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import cn.rtast.qwsdk.tests.utils.randomID
 import cn.rtast.qwsdk.utils.Coordinate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -42,11 +41,9 @@ class TestAstronomy {
 
     @Test
     fun solarElevationAngleTest() {
-        if (!isFreePlan()) {
-            val result = qw.astronomy().solarElevationAngle(
-                Coordinate(116.41, 39.92), "20170809", "1230", "0800", 43
-            )
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.astronomy().solarElevationAngle(
+            Coordinate(116.41, 39.92), "20170809", "1230", "0800", 43
+        )
+        assertEquals(result.code.toInt(), 200)
     }
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestGeo.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestGeo.kt
@@ -16,7 +16,7 @@
 
 package cn.rtast.qwsdk.tests.main
 
-import cn.rtast.qwsdk.enums.POIType
+import cn.rtast.qwsdk.QWeather.POIType
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.randomID
 import cn.rtast.qwsdk.utils.Coordinate

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestIndices.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestIndices.kt
@@ -17,7 +17,6 @@
 package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import cn.rtast.qwsdk.tests.utils.randomID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -34,9 +33,7 @@ class TestIndices {
 
     @Test
     fun indices3d() {
-        if (!isFreePlan()) {
-            val result = qw.indices().indices3d(locationID)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.indices().indices3d(locationID)
+        assertEquals(result.code.toInt(), 200)
     }
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestOcean.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestOcean.kt
@@ -18,7 +18,6 @@ package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.getCurrentDate
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -26,17 +25,13 @@ class TestOcean {
 
     @Test
     fun tideTest() {
-        if (!isFreePlan()) {
-            val result = qw.ocean().tide("P2951", getCurrentDate())
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.ocean().tide("P2951", getCurrentDate())
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun currentsTest() {
-        if (!isFreePlan()) {
-            val result = qw.ocean().currents("P66981", getCurrentDate())
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.ocean().currents("P66981", getCurrentDate())
+        assertEquals(result.code.toInt(), 200)
     }
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestTimeMachine.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestTimeMachine.kt
@@ -17,7 +17,6 @@
 package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import cn.rtast.qwsdk.tests.utils.randomID
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
@@ -28,17 +27,13 @@ class TestTimeMachine {
 
     @Test
     fun weatherHistoricalTest() {
-        if (!isFreePlan()) {
-            val result = qw.timeMachine().weatherHistory(locationID, "20200531")
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.timeMachine().weatherHistory(locationID, "20200531")
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun airHistoricalTest() {
-        if (!isFreePlan()) {
-            val result = qw.timeMachine().airHistory(locationID, "20200531")
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.timeMachine().airHistory(locationID, "20200531")
+        assertEquals(result.code.toInt(), 200)
     }
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestTropical.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestTropical.kt
@@ -18,7 +18,6 @@ package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.getCurrentYear
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
@@ -26,27 +25,21 @@ class TestTropical {
 
     @Test
     fun forecastTest() {
-        if (!isFreePlan()) {
-            val id = qw.tropical().list(getCurrentYear()).storm[0].id
-            val result = qw.tropical().forecast(id)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val id = qw.tropical().list(getCurrentYear()).storm[0].id
+        val result = qw.tropical().forecast(id)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun trackTest() {
-        if (!isFreePlan()) {
-            val id = qw.tropical().list(getCurrentYear()).storm[0].id
-            val result = qw.tropical().track(id)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val id = qw.tropical().list(getCurrentYear()).storm[0].id
+        val result = qw.tropical().track(id)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun listTest() {
-        if (!isFreePlan()) {
-            val result = qw.tropical().list(getCurrentYear())
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.tropical().list(getCurrentYear())
+        assertEquals(result.code.toInt(), 200)
     }
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestWarning.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestWarning.kt
@@ -16,8 +16,8 @@
 
 package cn.rtast.qwsdk.tests.main
 
-import cn.rtast.qwsdk.enums.CountryCode
-import cn.rtast.qwsdk.enums.Lang
+import cn.rtast.qwsdk.QWeather.CountryCode
+import cn.rtast.qwsdk.QWeather.Lang
 import cn.rtast.qwsdk.tests.Initial.qw
 import cn.rtast.qwsdk.tests.utils.randomID
 import org.junit.jupiter.api.Assertions

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestWeather.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/TestWeather.kt
@@ -17,7 +17,6 @@
 package cn.rtast.qwsdk.tests.main
 
 import cn.rtast.qwsdk.tests.Initial.qw
-import cn.rtast.qwsdk.tests.utils.isFreePlan
 import cn.rtast.qwsdk.tests.utils.randomID
 import cn.rtast.qwsdk.utils.Coordinate
 import org.junit.jupiter.api.Assertions.assertEquals
@@ -26,7 +25,7 @@ import org.junit.jupiter.api.Test
 class TestWeather {
 
     private val locationID = randomID()
-    private val coordinate = Coordinate(116.41,39.92)
+    private val coordinate = Coordinate(116.41, 39.92)
 
     @Test
     fun nowTest() {
@@ -48,18 +47,14 @@ class TestWeather {
 
     @Test
     fun weather72hTest() {
-        if (!isFreePlan()) {
             val result = qw.weather().weather72h(locationID)
             assertEquals(result.code.toInt(), 200)
-        }
     }
 
     @Test
     fun weather168hTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weather168h(locationID)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weather168h(locationID)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
@@ -76,50 +71,38 @@ class TestWeather {
 
     @Test
     fun weather15dTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weather15d(locationID)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weather15d(locationID)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun weatherGridNowTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weatherGridNow(coordinate)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weatherGridNow(coordinate)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun weatherGrid24hTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weatherGrid24h(coordinate)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weatherGrid24h(coordinate)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun weatherGrid72hTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weatherGrid72h(coordinate)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weatherGrid72h(coordinate)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun weatherGrid3dTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weatherGrid3d(coordinate)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weatherGrid3d(coordinate)
+        assertEquals(result.code.toInt(), 200)
     }
 
     @Test
     fun weatherGrid7dTest() {
-        if (!isFreePlan()) {
-            val result = qw.weather().weatherGrid7d(coordinate)
-            assertEquals(result.code.toInt(), 200)
-        }
+        val result = qw.weather().weatherGrid7d(coordinate)
+        assertEquals(result.code.toInt(), 200)
     }
 
 }

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/main/utils/TestParseIndices.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/main/utils/TestParseIndices.kt
@@ -16,7 +16,7 @@
 
 package cn.rtast.qwsdk.tests.main.utils
 
-import cn.rtast.qwsdk.enums.IndicesType
+import cn.rtast.qwsdk.QWeather.IndicesType
 import cn.rtast.qwsdk.utils.parseIndices
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/cn/rtast/qwsdk/tests/utils/Utils.kt
+++ b/src/test/kotlin/cn/rtast/qwsdk/tests/utils/Utils.kt
@@ -16,14 +16,9 @@
 
 package cn.rtast.qwsdk.tests.utils
 
-import cn.rtast.qwsdk.QWeather
 import java.text.SimpleDateFormat
-import java.util.Date
+import java.util.*
 import kotlin.random.Random
-
-fun isFreePlan(): Boolean {
-    return QWeather.rootAPI.contains("https://devapi")
-}
 
 fun randomID(): String {
     val idList = listOf(


### PR DESCRIPTION
# 修复若干问题

## 错误的参数校验

修复了 `Astronomy` 内太阳高度角 `solarElevationAngle` 对于时间的错误校验

![image](https://github.com/RTAkland/QWeatherSDK/assets/46998172/2ee60a27-d21c-4f75-924c-38211b4ae6f7)

## 初始化问题

修复了 `makeParam` 内 `result` 可能引发的初始化问题

![image](https://github.com/RTAkland/QWeatherSDK/assets/46998172/1037d486-5e88-4e2a-992f-b3b4cb2083aa)

## 错误的订阅计划检验

`Initial` 的初始化发生在调用 `qw` 对象时，在这之前调用 `isFreePlan` 去检验是否采用付费订阅是不合理的，因为请求链接还未修改

![image](https://github.com/RTAkland/QWeatherSDK/assets/46998172/d81d6f89-6700-44fb-a75d-b30491a168d7)

## 若干错误引用问题

